### PR TITLE
added huddle doc to cc guides folder

### DIFF
--- a/HUDDLE-SESSIONS.md
+++ b/HUDDLE-SESSIONS.md
@@ -1,0 +1,57 @@
+## Collaborative Sessions (Daily at 2pm UTC, in Slack Huddle: `#cc-dev-help`)
+Collaborative sessions provide structured time for working together on specific tasks or issues. These sessions take place daily at 2pm UTC in the Slack `#cc-dev-help` channel using the Slack Huddle feature.
+
+**How It Works**: If the session hasn’t started, feel free to initiate it. Wait a few minutes for others to join, and then collectively decide what to work on.
+
+**Who Facilitates?** A facilitator will be identified at the start of the session. This person helps guide the group in deciding how to use the time most effectively. This could be a quick, informal agreement among those present.
+
+**Collaborative Decision-Making** The group decides how to structure the time. If there are multiple participants with different needs, you can:
+  - Pair off and work on separate issues in smaller groups.
+  - Troubleshoot one problem together as a team, focusing on the most pressing issue.
+
+
+### Example Collaborative Session Activities
+1. **Work on a Problem Together**: Join forces to solve an issue or tackle a specific coding challenge.
+2. **Demo Creating an Issue**: Someone may walk through how to create an issue step-by-step, sharing their process for clarity.
+3. **Show and Tell (Demo Style)**: If you’ve completed a contribution (e.g., solving an issue, submitting a pull request, and getting it approved to merge), consider sharing your process during the session. You can walk the group through:
+   - How you chose the issue.
+   - The steps you took to solve the problem.
+   - The solution you implemented.
+   - How you created and submitted the pull request (PR).
+   - What details you included in the PR description.
+4. **Ask Questions** If you’re stuck on a specific problem, this is a great time to ask for help. Use the guidelines from the article [Getting Answers](https://www.mikeash.com/getting_answers.html):
+   - Clearly explain what’s not working.
+   - Provide as much information as possible upfront, including code.
+   - Share your research or steps taken before asking the question.
+
+These sessions are also a great opportunity to ask questions about any new PRs or issues. Remember to give `@sara` and `@Timid Robot` at least 48 hours to review PRs and issues. If you need clarification during the session, feel free to bring it up for discussion.
+---
+## Co-Working Sessions (Anytime)
+Co-working sessions are flexible and informal, taking place spontaneously in the same `#cc-dev-help` Slack channel. People can come and go as needed. One way these huddles can be used is for [doubling](https://psychcentral.com/adhd/adhd-body-doubling), a strategy for executive functioning and staying focused.
+**How It Works**: The first person to start the huddle acts as the initial facilitator, but anyone can participate, ask questions, and contribute to the discussion.
+
+**Less Structured**: Co-working sessions don’t have a set agenda. They are ideal for:
+  - Asking general questions about contributing to the project.
+  - Meeting other applicants
+  - Getting to know each other as humans
+
+Facilitators (the person who started the huddle or anyone else available) can guide new participants by directing them to pinned messages or resources, and helping answer simple or high-level questions about the contribution process. Co-working sessions are also a great space for developers to casually work side by side, share tips, or receive support when feeling discouraged.
+---
+
+### Key Points to Remember
+
+**Collaborative Sessions** focus on working together on issues, while **Co-Working Sessions** are more open-ended and casual.
+
+- In collaborative sessions, the group decides how to use the time, and can either work together or in smaller groups.
+- Co-working sessions are ideal for newcomers who need help or want to get familiar with the project.
+- Feel free to jump in or out of co-working sessions at any time. If you’re stuck, the facilitator will point you to the right resources.
+- One participant of the huddle can volunteer to summarize the activities that occurred during the huddle so as to help others that were not able to attend that particular huddle. This would also serve as reference for topics covered and could be compiled into a FAQ compilation.
+
+These sessions are designed to support all participants, no matter their level of experience, and to encourage open collaboration and communication.
+
+Date created: 10/14/2024
+Authors: Laura Castro and Victor Egbadon
+Purpose: Provide a structure for huddles cc-dev-help channel
+
+
+


### PR DESCRIPTION
I realized that i didn't add the documentation about huddles to the cc-guides folder. Now it should be in there.